### PR TITLE
Require `pantheon_version` to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
+| `pantheon_version` | ___unset___ | Version of Pantheon to install and run  __REQUIRED__ |
 | `pantheon_user` | pantheon | Pantheon user |
 | `pantheon_group` | pantheon | Pantheon group |
-| `pantheon_version` | ___unset___ | Version of Pantheon to install and run  __REQUIRED__ |
 | `pantheon_download_url` | https://bintray.com/consensys/pegasys-repo/download_file?file_path=pantheon-{{ pantheon_version }}.tar.gz | The download tar.gz file used. You can use this if you need to retrieve pantheon from a custom location such as an internal repository. |
 | `pantheon_install_dir` | /opt/pantheon | Path to install to  |
 | `pantheon_config_dir` | /etc/pantheon | Path for default configuration |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `pantheon_user` | pantheon | Pantheon user |
 | `pantheon_group` | pantheon | Pantheon group |
-| `pantheon_version` | 1.2.0 | Current stable version of Pantheon |
+| `pantheon_version` | ___unset___ | Version of Pantheon to install and run  __REQUIRED__ |
 | `pantheon_download_url` | https://bintray.com/consensys/pegasys-repo/download_file?file_path=pantheon-{{ pantheon_version }}.tar.gz | The download tar.gz file used. You can use this if you need to retrieve pantheon from a custom location such as an internal repository. |
 | `pantheon_install_dir` | /opt/pantheon | Path to install to  |
 | `pantheon_config_dir` | /etc/pantheon | Path for default configuration |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ pantheon_user: pantheon
 pantheon_group: "{{ pantheon_user }}"
 
 # Version to install
-pantheon_version: 1.2.0
 pantheon_download_url: "https://bintray.com/consensys/pegasys-repo/download_file?file_path=pantheon-{{ pantheon_version }}.tar.gz"
 
 # Directory paths

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,11 +9,11 @@ pantheon_download_url: "https://bintray.com/consensys/pegasys-repo/download_file
 
 # Directory paths
 pantheon_base_dir: "/opt/pantheon"
-pantheon_install_dir: "{{pantheon_base_dir}}/pantheon-{{pantheon_version}}"
-pantheon_current_dir: "{{pantheon_base_dir}}/current"
+pantheon_install_dir: "{{ pantheon_base_dir }}/pantheon-{{ pantheon_version }}"
+pantheon_current_dir: "{{ pantheon_base_dir }}/current"
 pantheon_config_dir: "/etc/pantheon"
 pantheon_config_template: "config.toml.j2"
-pantheon_data_dir: "{{pantheon_base_dir}}/data"
+pantheon_data_dir: "{{ pantheon_base_dir }}/data"
 pantheon_log_dir: "/var/log/pantheon"
 pantheon_profile_file: "/etc/profile.d/pantheon-path.sh"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure we have pantheon_version
+  fail:
+    msg: You must set "pantheon_version" for this role to run
+  when: pantheon_version is not defined
+
 - name: Include OS and distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
Allows this repo and utility to be totally separate in release cadence from the main pantheon repo, while still making it as simple as possible for people to know what went wrong.

Also helps to prevent unfortunate changes to the infrastructure as a result of different versions of this being pulled with different `pantheon_version`s being set.